### PR TITLE
Add MS megadetector class and visualizer

### DIFF
--- a/deertracker/model.py
+++ b/deertracker/model.py
@@ -1,7 +1,9 @@
+from typing import Tuple
 import cv2
 import cvlib as cv
 import matplotlib.pyplot as plt
 import numpy as np
+import tensorflow as tf
 
 from cvlib.object_detection import draw_bbox
 from PIL import Image
@@ -29,3 +31,83 @@ def first_frame(video_path):
     vidcap = cv2.VideoCapture(video_path)
     success, image = vidcap.read()
     return Image.fromarray(image[:, :, ::-1].copy())
+
+
+class MegaDetector:
+    """
+    Microsoft's MegaDetector. https://github.com/microsoft/CameraTraps
+    """
+
+    def __init__(self, filepath: str):
+        """
+        Load the protobuf file, massage from TF 1.13.1 to TF 2.x
+
+        Inputs
+        ------
+        filepath : str
+            Path to the saved megadetector protobuf file. See download links in
+            https://github.com/microsoft/CameraTraps/blob/master/megadetector.md
+            This was tested with version 4.1
+        """
+        with tf.io.gfile.GFile(filepath, "rb") as f:
+            graph_def = tf.compat.v1.GraphDef()
+            graph_def.ParseFromString(f.read())
+
+        # Adapted from TF migration guide:
+        # https://www.tensorflow.org/guide/migrate#a_graphpb_or_graphpbtxt
+        def wrap_frozen_graph(graph_def, inputs, outputs):
+            def _imports_graph_def():
+                tf.compat.v1.import_graph_def(graph_def, name="")
+
+            wrapped_import = tf.compat.v1.wrap_function(_imports_graph_def, [])
+            import_graph = wrapped_import.graph
+            return wrapped_import.prune(
+                tf.nest.map_structure(import_graph.as_graph_element, inputs),
+                tf.nest.map_structure(import_graph.as_graph_element, outputs),
+            )
+
+        # You can see the names of the input/output tensors here:
+        # https://github.com/microsoft/CameraTraps/blob/master/detection/run_tf_detector.py#L150-L153
+        self.model = wrap_frozen_graph(
+            graph_def,
+            "image_tensor:0",
+            ["detection_boxes:0", "detection_classes:0", "detection_scores:0"],
+        )
+
+    def predict(
+        self, image: np.ndarray, confidence: float = 0.5
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Image -> bounding boxes.
+
+        Inputs
+        ------
+        image : np.ndarray
+            Input uint8 array with shape (width, height, 3)
+        confidence : float
+            Only bounding boxes with this level of confidence will be output.
+
+        Outputs
+        -------
+        bboxes : np.ndarray
+            Nx4 array of bounding boxes:
+                bboxes[i][0]  # starting x coordinate
+                bboxes[i][1]  # starting y coordinate
+                bboxes[i][2]  # width of bounding box
+                bboxes[i][3]  # height of bounding box
+        classes : np.ndarray
+            N-length array of class labels (integers)
+        scores : np.ndarray
+            N-length array of bounding box scores. Higher is better.
+            Use `confidence` to ignore bounding boxes below a confidence.
+        """
+        # model operates on batches, so add a singular dimension at the front.
+        tensor_input = tf.convert_to_tensor(image[None, :, :, :])
+        # the map below strips out the singular batch dimension
+        bboxes, classes, scores = map(lambda x: x.numpy()[0], self.model(tensor_input))
+        bboxes = bboxes[scores > confidence]
+        classes = classes[scores > confidence].astype("uint16")
+        scores = scores[scores > confidence]
+        # Need to convert fractions -> pixels
+        bboxes = np.round(bboxes * (image.shape[:2] * 2)).astype("uint16")
+        return bboxes, classes, scores

--- a/deertracker/visualize.py
+++ b/deertracker/visualize.py
@@ -1,0 +1,33 @@
+import matplotlib.pyplot as plt
+import cv2
+import numpy as np
+
+from .model import MegaDetector
+
+
+def show_megadetector(md: MegaDetector, image: np.ndarray):
+    """
+    Visualize Microsoft's MegaDetector bounding boxes.
+
+    Inputs
+    ------
+    image : np.ndarray
+        (width, height, 3) image array
+    """
+    bboxes, classes, scores = md.predict(image)
+    colors = [(255, 0, 0), (0, 255, 0), (0, 0, 255)]
+    for bbox, label, score in zip(bboxes, classes, scores):
+        color = colors[label]
+        cv2.rectangle(image, (bbox[0], bbox[1]), (bbox[2], bbox[3]), color, 2)
+        cv2.putText(
+            image,
+            str(label),
+            (bbox[0], bbox[1] - 10),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            color,
+            2,
+        )
+    plt.imshow(image)
+    plt.axis("off")
+    plt.show()


### PR DESCRIPTION
This PR adds a class to handle loading and predicting of the megadetector model. It's a little busy, mostly because I am migrating their TF1 model to work in TF2.

Pretty simple to use:

```python
from deertracker.visualize import show_megadetector
from deertracker.model import MegaDetector
import cv2
# Download the model (in .pb format):
# https://github.com/microsoft/CameraTraps/blob/master/megadetector.md#megadetector-v41-20200427
# point the initializer to wherever you downloaded it to
md = MegaDetector('models/megadetector/md_v4.1.0.pb')
# This is a random photo I got from the internet
# https://wtsolutions-rcgarkskyk9ln7qkrx.stackpathdns.com/uploads/blog/_blogLargeImage/wpid-2016-06-09-11.40.43.jpg
show_megadetector(md, cv2.imread('/Users/kevin/Downloads/wpid-2016-06-09-11.40.43.jpg'))
```

<img width="495" alt="image" src="https://user-images.githubusercontent.com/4053170/100376643-815fa280-2fd5-11eb-9c81-b2cc9ff9617d.png">
