### PR TITLE
Save and load the class names with the model

### DIFF
--- a/deertracker/classifier.py
+++ b/deertracker/classifier.py
@@ -47,7 +47,29 @@ class Linnaeus(tf.keras.Model):
 
 
 def load_model(model_path):
-    return tf.keras.models.load_model(model_path)
+    """
+    Return the model and the list of class names.
+
+    This relies on a file model_path / 'class_names.txt' that
+    is not standard to the tensorflow SavedModel format.
+
+    Inputs
+    ------
+    model_path : Path, str
+        Path to the folder where the model is saved.
+
+    Returns
+    -------
+    model
+        Tensorflow model
+    class_names
+        List of strings of the class names. Should satisfy
+        `len(class_names) == model.output_shape[1]`
+    """
+    model = tf.keras.models.load_model(model_path)
+    with open(Path(model_path) / "class_names.txt") as f:
+        class_names = f.read().split("\n")
+    return model, class_names
 
 
 def get_datasets(
@@ -254,3 +276,5 @@ def train(
             )
             model_with_prob_outputs.build((None, IMAGE_SIZE, IMAGE_SIZE, 3))
             model_with_prob_outputs.save(epoch_model_dir)
+            with open(epoch_model_dir / "class_names.txt", "w") as f:
+                f.write("\n".join(class_names))


### PR DESCRIPTION
Save an extra file in the tensorflow `SavedModel`-formatted folder which is the (newline separated) class names.

Update the `load_model` function to load those.

```python
>>> from deertracker.classifier import load_model
>>> import numpy as np
>>> model, class_names = load_model('models/v0/v0-0000/')
>>> probs = model(np.random.rand(1, 96, 96, 3)).numpy()[0]
>>> print(dict(zip(class_names, probs)))
{'bird': 0.012638564,
 'bobcat': 0.10234875,
 'car': 0.036802925,
 'cat': 0.031618234,
 'coyote': 0.202298,
 'deer': 0.032097068,
 'dog': 0.020285282,
 'fox': 0.06768719,
 'opossum': 0.24596149,
 'rabbit': 0.0074156583,
 'raccoon': 0.079121836,
 'rodent': 0.05822041,
 'skunk': 0.063956164,
 'squirrel': 0.039548416}
```